### PR TITLE
Update current.php

### DIFF
--- a/resources/current.php
+++ b/resources/current.php
@@ -100,7 +100,7 @@
   'BDT' => 
   array (
     'alphabeticCode' => 'BDT',
-    'currency' => 'Taka',
+    'currency' => 'Bangladeshi Taka',
     'minorUnit' => 2,
     'numericCode' => 50,
   ),


### PR DESCRIPTION
The term "Taka" is also used for Indian Rupee in some parts of India. So it should explicitly say "Bangladeshi Taka" to avoid any kind of confusion.